### PR TITLE
CTP-3742 Add locked field

### DIFF
--- a/classes/assess_type.php
+++ b/classes/assess_type.php
@@ -93,17 +93,14 @@ class assess_type {
     }
 
     /**
-     * Return if assess is sits mapped.
+     * Return if assess is locked.
      *
      * @param int $cmid The activity id.
      */
-    public static function is_sitsmapped(int $cmid): bool {
-        global $CFG;
-        // Check if local_sitsgradepush is installed.
-        if (file_exists($CFG->dirroot . '/local/sitsgradepush/version.php')) {
-            require_once($CFG->dirroot . '/local/sitsgradepush/classes/external/is_coursemodule_mapped.php');
-            $result = \local_sitsgradepush\external\is_coursemodule_mapped::execute($cmid);
-            return $result['mapped'];
+    public static function is_locked(int $cmid): bool {
+        global $DB;
+        if ($r = $DB->get_record('local_assess_type', ['cmid' => $cmid])) {
+            return $r->locked;
         }
         return false;
     }
@@ -114,8 +111,9 @@ class assess_type {
      * @param int $cmid - The mod id.
      * @param int $courseid - The course id.
      * @param int $type - formative/summative/dummy.
+     * @param int $locked - Lock field.
      */
-    public static function update_type(int $cmid, int $courseid, int $type) {
+    public static function update_type(int $cmid, int $courseid, int $type, int $locked = 0) {
         global $DB;
         $table = 'local_assess_type';
 
@@ -124,6 +122,7 @@ class assess_type {
         $r->type = $type;
         $r->cmid = $cmid;
         $r->courseid = $courseid;
+        $r->locked = $locked;
 
         // If record exists.
         if ($record = $DB->get_record($table, ['cmid' => $cmid], 'id, type')) {

--- a/db/install.xml
+++ b/db/install.xml
@@ -10,6 +10,7 @@
         <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Foreign key of course id"/>
         <FIELD NAME="cmid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Foreign key cm id"/>
         <FIELD NAME="type" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="The value of this datum"/>
+        <FIELD NAME="locked" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Locked field"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/lib.php
+++ b/lib.php
@@ -47,10 +47,10 @@ function local_assess_type_coursemodule_standard_elements($formwrapper, $mform) 
     if ($cmid = $cm->coursemodule) {
         $newcm = false;
     }
-    // Flag if sits mapped.
-    $sitsmapped = false;
+    // Flag if locked (normally by SITS marks transfer plugin).
+    $locked = false;
     if ($cmid) {
-        $sitsmapped = assess_type::is_sitsmapped($cmid);
+        $locked = assess_type::is_locked($cmid);
     }
 
     // Mform element.
@@ -62,8 +62,8 @@ function local_assess_type_coursemodule_standard_elements($formwrapper, $mform) 
     $attributes = [];
     $attributes['required'] = 'required';
 
-    // Disable changes when sits mapped.
-    if ($sitsmapped) {
+    // Disable changes when locked.
+    if ($locked) {
         $attributes['disabled'] = 'disabled';
     }
     $select = $mform->createElement(
@@ -74,13 +74,13 @@ function local_assess_type_coursemodule_standard_elements($formwrapper, $mform) 
         $attributes
     );
 
-    // Set to summative when sits mapped.
-    if ($sitsmapped) {
+    // Set to summative when locked.
+    if ($locked) {
         $select->setSelected(1);
     }
 
-    // Set existing option from db (when not sits mapped or new).
-    if (!$sitsmapped && $cmid) {
+    // Set existing option from db (when not locked or new).
+    if (!$locked && $cmid) {
         if ($record = $DB->get_record('local_assess_type', ['cmid' => $cmid], 'type')) {
             $select->setSelected($record->type);
         }


### PR DESCRIPTION
Add locked field to be updated by SITS mark transfer. Use this new field to see if assessment type is locked, instead of calling sits plugin.