### PR TITLE
CTP-4028 Fix: get_type_name() null when formative

### DIFF
--- a/classes/assess_type.php
+++ b/classes/assess_type.php
@@ -74,7 +74,7 @@ class assess_type {
      * @param int $cmid
      */
     public static function get_type_name(int $cmid): ?string {
-        if ($typeint = self::get_type_int($cmid)) {
+        if (($typeint = self::get_type_int($cmid)) !== null) {
             switch ($typeint) {
                 case self::ASSESS_TYPE_FORMATIVE:
                     return get_string('formative', 'local_assess_type');

--- a/tests/assess_type_test.php
+++ b/tests/assess_type_test.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_assess_type;
+
+/**
+ * PHPUnit tests for local_assess_type.
+ *
+ * @package    local_assess_type
+ * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Leon Stringer <leon.stringer@ucl.ac.uk>
+ */
+final class assess_type_test extends \advanced_testcase {
+    /**
+     * Test strings returned by assess_type::get_type_name() are the expected
+     * values.
+     * @covers \local_assess_type\assess_type::get_type_name
+     * @dataProvider assess_type_strings
+     * @param int $assesstype ASSESS_TYPE_FORMATIVE, ASSESS_TYPE_SUMMATIVE,
+     * etc.
+     * @param string $name "Formative", "Summative", etc.
+     */
+    public function test_get_type_name(int $assesstype, string $name): void {
+        $this->resetAfterTest(true);
+
+        // Make a course.
+        $course = $this->getDataGenerator()->create_course();
+
+        // Make a quiz and add it to the course.
+        $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
+        $quiz = $quizgenerator->create_instance(['course' => $course->id, 'questionsperpage' => 0,
+            'grade' => 100.0, 'sumgrades' => 2, 'preferredbehaviour' => 'immediatefeedback']);
+
+        $cm = get_coursemodule_from_instance('quiz', $quiz->id, $course->id);
+        assess_type::update_type($course->id, $assesstype, $cm->id);
+        $this->assertEquals(assess_type::get_type_name($cm->id), $name);
+
+    }
+
+    /**
+     * Data provider.
+     */
+    public static function assess_type_strings(): array {
+        return [
+            'formative' => [
+                'assess_type' => assess_type::ASSESS_TYPE_FORMATIVE,
+                'name' => get_string('formative', 'local_assess_type'),
+            ],
+            'summative' => [
+                'assess_type' => assess_type::ASSESS_TYPE_SUMMATIVE,
+                'name' => get_string('summative', 'local_assess_type'),
+            ],
+            'dummy' => [
+                'assess_type' => assess_type::ASSESS_TYPE_DUMMY,
+                'name' => get_string('dummy', 'local_assess_type'),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Previously assess_type::get_type_name() would return null for modules set to ASSESS_TYPE_FORMATIVE.