### PR TITLE
Ctp 5218 6322

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             database: 'mariadb'
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             database: 'pgsql'
-          - php: '8.2'
+          - php: '8.3'
             moodle-branch: 'main'
             database: 'mariadb'
-          - php: '8.2'
+          - php: '8.3'
             moodle-branch: 'main'
             database: 'pgsql'
           - php: '8.3'
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: plugin
 

--- a/backup/moodle2/backup_local_assess_type_plugin.class.php
+++ b/backup/moodle2/backup_local_assess_type_plugin.class.php
@@ -18,7 +18,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/backup/moodle2/backup_local_plugin.class.php');
 
 /**
- * Defines backup_local_assess_type_plugin class
+ * Defines backup_local_assess_type_plugin class.
  *
  * @package    local_assess_type
  * @copyright  2025 onwards University College London {@link https://www.ucl.ac.uk/}
@@ -26,25 +26,37 @@ require_once($CFG->dirroot . '/backup/moodle2/backup_local_plugin.class.php');
  * @author     Alex Yeung <k.yeung@ucl.ac.uk>
  */
 class backup_local_assess_type_plugin extends backup_local_plugin {
-
     /**
-     * Define course plugin structure
+     * Define course plugin structure.
      *
      * @return backup_plugin_element
-     * @throws base_element_struct_exception
      */
     protected function define_course_plugin_structure(): backup_plugin_element {
-        $plugin = $this->get_plugin_element();
+        return $this->build_plugin_structure(['courseid' => backup::VAR_COURSEID]);
+    }
 
+    /**
+     * Define module plugin structure for single-activity backup (used during duplication).
+     *
+     * @return backup_plugin_element
+     */
+    protected function define_module_plugin_structure(): backup_plugin_element {
+        return $this->build_plugin_structure(['cmid' => backup::VAR_MODID]);
+    }
+
+    /**
+     * Build the plugin element structure with the given source condition.
+     *
+     * @param array $sourcecondition Source table filter passed to set_source_table.
+     * @return backup_plugin_element
+     */
+    private function build_plugin_structure(array $sourcecondition): backup_plugin_element {
+        $plugin = $this->get_plugin_element();
         $wrapper = new backup_nested_element($this->get_recommended_name());
         $assesstypedata = new backup_nested_element('assess_type', ['id'], ['cmid', 'gradeitemid', 'type', 'locked']);
-
         $wrapper->add_child($assesstypedata);
         $plugin->add_child($wrapper);
-
-        // Set source table for backup.
-        $assesstypedata->set_source_table('local_assess_type', ['courseid' => backup::VAR_COURSEID]);
-
+        $assesstypedata->set_source_table('local_assess_type', $sourcecondition);
         return $plugin;
     }
 }

--- a/backup/moodle2/restore_local_assess_type_plugin.class.php
+++ b/backup/moodle2/restore_local_assess_type_plugin.class.php
@@ -28,6 +28,55 @@ require_once($CFG->dirroot . '/backup/moodle2/restore_local_plugin.class.php');
  * @author     Alex Yeung <k.yeung@ucl.ac.uk>
  */
 class restore_local_assess_type_plugin extends restore_local_plugin {
+    /**
+     * Save the assessment type data to cache during course restore.
+     *
+     * @param mixed $data Assessment type data.
+     */
+    public function process_assess_type_course(mixed $data): void {
+        $this->cache_data($this->get_cache_key(), $data);
+    }
+
+    /**
+     * Save the assessment type data to cache during module restore.
+     *
+     * @param mixed $data Assessment type data.
+     */
+    public function process_assess_type_module(mixed $data): void {
+        $this->cache_data($this->get_cache_key(true), $data);
+    }
+
+    /**
+     * Process the assessment type data after course restoration.
+     */
+    public function after_restore_course(): void {
+        $this->restore_records($this->get_cache_key());
+    }
+
+    /**
+     * Process the assessment type data after module restoration (used during duplication).
+     */
+    public function after_restore_module(): void {
+        $this->restore_records($this->get_cache_key(true));
+    }
+
+    /**
+     * Define course plugin structure.
+     *
+     * @return array Plugin structure paths.
+     */
+    protected function define_course_plugin_structure(): array {
+        return [new restore_path_element('assess_type_course', $this->get_pathfor('/assess_type'))];
+    }
+
+    /**
+     * Define module plugin structure for single-activity restore (used during duplication).
+     *
+     * @return array Plugin structure paths.
+     */
+    protected function define_module_plugin_structure(): array {
+        return [new restore_path_element('assess_type_module', $this->get_pathfor('/assess_type'))];
+    }
 
     /**
      * Gets the cache instance for storing restore data.
@@ -41,59 +90,58 @@ class restore_local_assess_type_plugin extends restore_local_plugin {
     /**
      * Gets the cache key for the current course.
      *
+     * @param bool $module Whether the key is for a module-level restore.
      * @return string Cache key.
      */
-    private function get_cache_key(): string {
-        return 'restore_data_' . $this->task->get_courseid();
+    private function get_cache_key(bool $module = false): string {
+        $prefix = $module ? 'restore_data_module_' : 'restore_data_';
+        return $prefix . $this->task->get_courseid();
     }
 
     /**
-     * Define course plugin structure.
+     * Appends data to a cache key's array.
      *
-     * @return array Plugin structure paths.
+     * @param string $key Cache key.
+     * @param mixed $data Data to append.
      */
-    protected function define_course_plugin_structure(): array {
-        return [new restore_path_element('assess_type_course', $this->get_pathfor('/assess_type'))];
-    }
-
-    /**
-     * Save the assessment type data to cache.
-     *
-     * @param mixed $data Assessment type data.
-     */
-    public function process_assess_type_course(mixed $data): void {
+    private function cache_data(string $key, mixed $data): void {
         $cache = $this->get_cache();
-        $key = $this->get_cache_key();
         $dataarray = $cache->get($key) ?: [];
         $dataarray[] = (object)$data;
         $cache->set($key, $dataarray);
     }
 
     /**
-     * Process the assessment type data after course restoration.
+     * Writes cached assessment type records to the database using the given cache key.
+     *
+     * @param string $cachekey Cache key to read from.
      */
-    public function after_restore_course(): void {
+    private function restore_records(string $cachekey): void {
         global $DB;
         $courseid = $this->task->get_courseid();
-        $dataarray = $this->get_cache()->get($this->get_cache_key());
+        $dataarray = $this->get_cache()->get($cachekey);
 
         if (empty($dataarray) || !is_array($dataarray)) {
             return;
         }
 
-        // Process each assessment type record.
+        $fieldmappings = ['cmid' => 'course_module', 'gradeitemid' => 'grade_item'];
+
         foreach ($dataarray as $data) {
             $data->courseid = $courseid;
             $data->locked = 0;
 
-            // Map course module id if present.
-            if (!empty($data->cmid) && $newcmid = $this->get_mappingid('course_module', $data->cmid)) {
-                $data->cmid = $newcmid;
-                $DB->insert_record('local_assess_type', $data);
-            } else if (!empty($data->gradeitemid) && $newgradeitemid = $this->get_mappingid('grade_item', $data->gradeitemid)) {
-                $data->gradeitemid = $newgradeitemid;
-                $DB->insert_record('local_assess_type', $data);
+            foreach ($fieldmappings as $field => $mappingtype) {
+                if (!empty($data->$field) && $newid = $this->get_mappingid($mappingtype, $data->$field)) {
+                    $data->$field = $newid;
+                    if (!$DB->record_exists('local_assess_type', [$field => $newid, 'courseid' => $courseid])) {
+                        $DB->insert_record('local_assess_type', $data);
+                    }
+                    break;
+                }
             }
         }
+
+        $this->get_cache()->delete($cachekey);
     }
 }

--- a/classes/assess_type.php
+++ b/classes/assess_type.php
@@ -25,7 +25,6 @@ namespace local_assess_type;
  * @author     Stuart Lamour <s.lamour@ucl.ac.uk>
  */
 class assess_type {
-
     /** @var int Assessment type formative */
     const ASSESS_TYPE_FORMATIVE = 0;
 
@@ -122,7 +121,7 @@ class assess_type {
      *
      * @throws \dml_exception
      */
-    public static function update_type(int $courseid, int $type, int $cmid = 0, int $gradeitemid = 0,  int $locked = 0): void {
+    public static function update_type(int $courseid, int $type, int $cmid = 0, int $gradeitemid = 0, int $locked = 0): void {
         global $DB;
         $table = 'local_assess_type';
 

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_assess_type;
+
+use core\event\course_module_deleted;
+use core\event\grade_item_deleted;
+
+/**
+ * Event observer class for local_assess_type.
+ *
+ * @package    local_assess_type
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class observer {
+    /**
+     * Handle course module deleted event.
+     *
+     * @param course_module_deleted $event
+     * @return void
+     */
+    public static function course_module_deleted(course_module_deleted $event): void {
+        global $DB;
+        $DB->delete_records('local_assess_type', ['cmid' => $event->objectid]);
+    }
+
+    /**
+     * Handle grade item deleted event.
+     *
+     * @param grade_item_deleted $event
+     * @return void
+     */
+    public static function grade_item_deleted(grade_item_deleted $event): void {
+        global $DB;
+        $DB->delete_records('local_assess_type', ['gradeitemid' => $event->objectid]);
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -32,7 +32,6 @@ namespace local_assess_type\privacy;
  * @author     Stuart Lamour <s.lamour@ucl.ac.uk>
  */
 class provider implements \core_privacy\local\metadata\null_provider {
-
     /**
      * Return privacy string.
      *

--- a/classes/task/delete_orphan_records.php
+++ b/classes/task/delete_orphan_records.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_assess_type\task;
+
+use core\task\scheduled_task;
+
+/**
+ * Scheduled task to delete orphaned assessment type records.
+ *
+ * @package    local_assess_type
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class delete_orphan_records extends scheduled_task {
+    /**
+     * Get a descriptive name for this task.
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        return get_string('task:deleteorphanrecords:name', 'local_assess_type');
+    }
+
+    /**
+     * Run the scheduled task.
+     *
+     * @return void
+     */
+    public function execute(): void {
+        global $DB;
+
+        $orphanids = [];
+
+        // Find records where cmid references a deleted course module.
+        $sql = "SELECT a.id
+                FROM {local_assess_type} a
+                LEFT JOIN {course_modules} cm ON cm.id = a.cmid
+                WHERE a.cmid != 0 AND cm.id IS NULL";
+        $orphanids = array_merge($orphanids, $DB->get_fieldset_sql($sql));
+
+        // Find records where gradeitemid references a deleted grade item.
+        $sql = "SELECT a.id
+                FROM {local_assess_type} a
+                LEFT JOIN {grade_items} gi ON gi.id = a.gradeitemid
+                WHERE a.gradeitemid != 0 AND gi.id IS NULL";
+        $orphanids = array_merge($orphanids, $DB->get_fieldset_sql($sql));
+
+        if (empty($orphanids)) {
+            mtrace('No orphaned assessment type records found.');
+            return;
+        }
+
+        [$insql, $params] = $DB->get_in_or_equal($orphanids);
+        $DB->delete_records_select('local_assess_type', "id $insql", $params);
+
+        mtrace(count($orphanids) . ' orphaned assessment type record(s) deleted.');
+    }
+}

--- a/classes/task/delete_orphan_records.php
+++ b/classes/task/delete_orphan_records.php
@@ -44,20 +44,20 @@ class delete_orphan_records extends scheduled_task {
     public function execute(): void {
         global $DB;
 
-        $orphanids = [];
-
         // Find records where cmid references a deleted course module.
         $sql = "SELECT a.id
                 FROM {local_assess_type} a
                 LEFT JOIN {course_modules} cm ON cm.id = a.cmid
-                WHERE a.cmid != 0 AND cm.id IS NULL";
-        $orphanids = array_merge($orphanids, $DB->get_fieldset_sql($sql));
+                WHERE a.cmid != 0
+                AND cm.id IS NULL";
+        $orphanids = $DB->get_fieldset_sql($sql);
 
         // Find records where gradeitemid references a deleted grade item.
         $sql = "SELECT a.id
                 FROM {local_assess_type} a
                 LEFT JOIN {grade_items} gi ON gi.id = a.gradeitemid
-                WHERE a.gradeitemid != 0 AND gi.id IS NULL";
+                WHERE a.gradeitemid != 0
+                AND gi.id IS NULL";
         $orphanids = array_merge($orphanids, $DB->get_fieldset_sql($sql));
 
         if (empty($orphanids)) {

--- a/db/events.php
+++ b/db/events.php
@@ -15,18 +15,23 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Version.
+ * Event observers for local_assess_type.
  *
  * @package    local_assess_type
- * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author     Stuart Lamour <s.lamour@ucl.ac.uk>
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'local_assess_type';
-$plugin->release = '1.0';
-$plugin->version = 2026051900; // YYYYMMDD.
-$plugin->requires = 2023100900;
-$plugin->maturity = MATURITY_STABLE;
+$observers = [
+    [
+        'eventname' => '\core\event\course_module_deleted',
+        'callback'  => '\local_assess_type\observer::course_module_deleted',
+    ],
+    [
+        'eventname' => '\core\event\grade_item_deleted',
+        'callback'  => '\local_assess_type\observer::grade_item_deleted',
+    ],
+];

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/assess_type/db" VERSION="20240913" COMMENT="XMLDB file for UCL"
+<XMLDB PATH="local/assess_type/db" VERSION="20250519" COMMENT="XMLDB file for UCL"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -16,6 +16,10 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="cmid" UNIQUE="false" FIELDS="cmid"/>
+        <INDEX NAME="gradeitemid" UNIQUE="false" FIELDS="gradeitemid"/>
+      </INDEXES>
     </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -15,18 +15,24 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Version.
+ * Scheduled tasks definition for local_assess_type.
  *
  * @package    local_assess_type
- * @copyright  2024 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @author     Stuart Lamour <s.lamour@ucl.ac.uk>
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'local_assess_type';
-$plugin->release = '1.0';
-$plugin->version = 2026051900; // YYYYMMDD.
-$plugin->requires = 2023100900;
-$plugin->maturity = MATURITY_STABLE;
+$tasks = [
+    [
+        'classname' => 'local_assess_type\task\delete_orphan_records',
+        'blocking'  => 0,
+        'minute'    => '0',
+        'hour'      => '3',
+        'day'       => '*',
+        'month'     => '*',
+        'dayofweek' => '*',
+    ],
+];

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -28,11 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 $tasks = [
     [
         'classname' => 'local_assess_type\task\delete_orphan_records',
-        'blocking'  => 0,
-        'minute'    => '0',
-        'hour'      => '3',
-        'day'       => '*',
-        'month'     => '*',
-        'dayofweek' => '*',
+        'minute' => '0',
+        'hour'     => '3',
     ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -63,5 +63,22 @@ function xmldb_local_assess_type_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024091300, 'local', 'assess_type');
     }
 
+    if ($oldversion < 2026051900) {
+        $table = new xmldb_table('local_assess_type');
+
+        $index = new xmldb_index('cmid', XMLDB_INDEX_NOTUNIQUE, ['cmid']);
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        $index = new xmldb_index('gradeitemid', XMLDB_INDEX_NOTUNIQUE, ['gradeitemid']);
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Local_assess_type savepoint reached.
+        upgrade_plugin_savepoint(true, 2026051900, 'local', 'assess_type');
+    }
+
     return true;
 }

--- a/lang/en/local_assess_type.php
+++ b/lang/en/local_assess_type.php
@@ -40,4 +40,5 @@ $string['settings:enable:desc'] = 'Enable the assessment type plugin for course 
 $string['settings:pagename'] = 'Assessment type settings';
 $string['summative'] = 'Summative';
 $string['summativeoption'] = 'Summative - counts towards the final module mark';
+$string['task:deleteorphanrecords:name'] = 'Delete orphaned assessment type records';
 $string['warning'] = 'This activity must be marked as Formative or Summative.';

--- a/lib.php
+++ b/lib.php
@@ -101,10 +101,12 @@ function local_assess_type_coursemodule_standard_elements($formwrapper, $mform) 
             '</a>';
     }
 
-    $info = $mform->createElement('html',
+    $info = $mform->createElement(
+        'html',
         '<div class="col-md-9 offset-md-3 pb-3">'
             . get_string('info', 'local_assess_type') . $link .
-        '</div>');
+        '</div>'
+    );
 
     // Add form elements to the dom.
     $mform->insertElementBefore($select, 'introeditor');

--- a/settings.php
+++ b/settings.php
@@ -28,17 +28,17 @@ defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
     $ADMIN->add(
-      'localplugins',
-      new admin_category('local_assess_type_settings', new lang_string('pluginname', 'local_assess_type'))
+        'localplugins',
+        new admin_category('local_assess_type_settings', new lang_string('pluginname', 'local_assess_type'))
     );
     $settings = new admin_settingpage('managelocalassesstype', new lang_string('settings:pagename', 'local_assess_type'));
 
     // Setting to enable/disable the plugin.
     $settings->add(new admin_setting_configcheckbox(
-      'local_assess_type/enabled',
-      get_string('settings:enable', 'local_assess_type'),
-      get_string('settings:enable:desc', 'local_assess_type'),
-      '1'
+        'local_assess_type/enabled',
+        get_string('settings:enable', 'local_assess_type'),
+        get_string('settings:enable:desc', 'local_assess_type'),
+        '1'
     ));
 
     $ADMIN->add('localplugins', $settings);

--- a/tests/assess_type_test.php
+++ b/tests/assess_type_test.php
@@ -48,7 +48,6 @@ final class assess_type_test extends \advanced_testcase {
         $cm = get_coursemodule_from_instance('quiz', $quiz->id, $course->id);
         assess_type::update_type($course->id, $assesstype, $cm->id);
         $this->assertEquals(assess_type::get_type_name($cm->id), $name);
-
     }
 
     /**

--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -1,0 +1,87 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_assess_type;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/course/lib.php');
+require_once($CFG->libdir . '/gradelib.php');
+
+/**
+ * PHPUnit tests for local_assess_type observer.
+ *
+ * @package    local_assess_type
+ * @copyright  2026 onwards University College London {@link https://www.ucl.ac.uk/}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @author     Alex Yeung <k.yeung@ucl.ac.uk>
+ */
+final class observer_test extends \advanced_testcase {
+    /**
+     * Test setup.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest();
+        $this->setAdminUser();
+    }
+
+    /**
+     * Test deleting a course module removes the assess_type record.
+     *
+     * @covers \local_assess_type\observer::course_module_deleted
+     */
+    public function test_deleting_module_removes_assess_type_record(): void {
+        global $DB;
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
+        assess_type::update_type($course->id, assess_type::ASSESS_TYPE_SUMMATIVE, $quiz->cmid);
+
+        // Verify assess type record exists for the quiz.
+        $this->assertTrue($DB->record_exists('local_assess_type', ['cmid' => $quiz->cmid]));
+
+        course_delete_module($quiz->cmid);
+
+        // Verify assess type record is deleted.
+        $this->assertFalse($DB->record_exists('local_assess_type', ['cmid' => $quiz->cmid]));
+    }
+
+    /**
+     * Test deleting a manual grade item removes the assess_type record.
+     *
+     * @covers \local_assess_type\observer::grade_item_deleted
+     */
+    public function test_deleting_grade_item_removes_assess_type_record(): void {
+        global $DB;
+        $course = $this->getDataGenerator()->create_course();
+        $gradeitem = $this->getDataGenerator()->create_grade_item([
+            'courseid' => $course->id,
+            'itemtype' => 'manual',
+            'itemname' => 'Test Grade Item',
+        ]);
+        assess_type::update_type($course->id, assess_type::ASSESS_TYPE_SUMMATIVE, 0, $gradeitem->id);
+
+        // Verify assess type record exists for the grade item.
+        $this->assertTrue($DB->record_exists('local_assess_type', ['gradeitemid' => $gradeitem->id]));
+
+        $item = \grade_item::fetch(['id' => $gradeitem->id]);
+        $item->delete('test');
+
+        // Verify assess type record is deleted.
+        $this->assertFalse($DB->record_exists('local_assess_type', ['gradeitemid' => $gradeitem->id]));
+    }
+}

--- a/tests/restore_local_assess_type_plugin_test.php
+++ b/tests/restore_local_assess_type_plugin_test.php
@@ -21,6 +21,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
 require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
+require_once($CFG->dirroot . '/course/lib.php');
 require_once($CFG->dirroot . '/local/assess_type/backup/moodle2/restore_local_assess_type_plugin.class.php');
 
 /**
@@ -32,7 +33,6 @@ require_once($CFG->dirroot . '/local/assess_type/backup/moodle2/restore_local_as
  * @author     Alex Yeung <k.yeung@ucl.ac.uk>
  */
 final class restore_local_assess_type_plugin_test extends \advanced_testcase {
-
     /**
      * Test setup.
      */
@@ -50,8 +50,14 @@ final class restore_local_assess_type_plugin_test extends \advanced_testcase {
      */
     protected function create_backup_file($course): \stored_file {
         make_backup_temp_directory($course->id);
-        $bc = new \backup_controller(\backup::TYPE_1COURSE, $course->id,
-            \backup::FORMAT_MOODLE, \backup::INTERACTIVE_NO, \backup::MODE_GENERAL, 2);
+        $bc = new \backup_controller(
+            \backup::TYPE_1COURSE,
+            $course->id,
+            \backup::FORMAT_MOODLE,
+            \backup::INTERACTIVE_NO,
+            \backup::MODE_GENERAL,
+            2
+        );
         $bc->execute_plan();
         $results = $bc->get_results();
         $bc->destroy();
@@ -77,17 +83,8 @@ final class restore_local_assess_type_plugin_test extends \advanced_testcase {
             'itemname' => 'Manual Grade Item', 'grademax' => 100,
         ]);
 
-        // Create assess types.
-        $DB->insert_records('local_assess_type', [
-            [
-                'courseid' => $course->id, 'cmid' => $assign->cmid,
-                'gradeitemid' => 0, 'type' => 1, 'locked' => 1,
-            ],
-            [
-                'courseid' => $course->id, 'cmid' => 0,
-                'gradeitemid' => $gradeitem->id, 'type' => 0, 'locked' => 0,
-            ],
-        ]);
+        assess_type::update_type($course->id, assess_type::ASSESS_TYPE_SUMMATIVE, $assign->cmid, 0, 1);
+        assess_type::update_type($course->id, assess_type::ASSESS_TYPE_FORMATIVE, 0, $gradeitem->id);
 
         // Backup and restore to new course.
         $backupfile = $this->create_backup_file($course);
@@ -95,8 +92,14 @@ final class restore_local_assess_type_plugin_test extends \advanced_testcase {
         $backuppath = $CFG->tempdir . '/backup/test_restore';
         $backupfile->extract_to_pathname(get_file_packer('application/vnd.moodle.backup'), $backuppath);
 
-        $rc = new \restore_controller('test_restore', $destcourse->id,
-            \backup::INTERACTIVE_NO, \backup::MODE_GENERAL, $USER->id, \backup::TARGET_NEW_COURSE);
+        $rc = new \restore_controller(
+            'test_restore',
+            $destcourse->id,
+            \backup::INTERACTIVE_NO,
+            \backup::MODE_GENERAL,
+            $USER->id,
+            \backup::TARGET_NEW_COURSE
+        );
         $rc->execute_precheck();
         $rc->execute_plan();
 
@@ -129,5 +132,73 @@ final class restore_local_assess_type_plugin_test extends \advanced_testcase {
         $rc->destroy();
         $backupfile->delete();
         remove_dir($backuppath);
+    }
+
+    /**
+     * Data provider for test_duplicate_module_copies_assess_type.
+     *
+     * @return array
+     */
+    public static function duplicate_module_assess_type_provider(): array {
+        return [
+            'summative is copied'  => [assess_type::ASSESS_TYPE_SUMMATIVE, 0, assess_type::ASSESS_TYPE_SUMMATIVE, 0],
+            'formative is copied'  => [assess_type::ASSESS_TYPE_FORMATIVE, 0, assess_type::ASSESS_TYPE_FORMATIVE, 0],
+            'locked flag is reset' => [assess_type::ASSESS_TYPE_SUMMATIVE, 1, assess_type::ASSESS_TYPE_SUMMATIVE, 0],
+        ];
+    }
+
+    /**
+     * Test duplicating an activity copies the assess type and resets locked to 0.
+     *
+     * @dataProvider duplicate_module_assess_type_provider
+     * @covers \restore_local_assess_type_plugin::process_assess_type_module
+     * @covers \restore_local_assess_type_plugin::after_restore_module
+     * @param int $originaltype Original assessment type value.
+     * @param int $originallocked Original locked value.
+     * @param int $expectedtype Expected type on the duplicate.
+     * @param int $expectedlocked Expected locked value on the duplicate.
+     */
+    public function test_duplicate_module_copies_assess_type(
+        int $originaltype,
+        int $originallocked,
+        int $expectedtype,
+        int $expectedlocked
+    ): void {
+        global $DB;
+        [$course, $assign] = $this->create_course_with_assign();
+        assess_type::update_type($course->id, $originaltype, $assign->cmid, 0, $originallocked);
+
+        $newcm = duplicate_module($course, get_fast_modinfo($course)->get_cm($assign->cmid));
+
+        $record = $DB->get_record('local_assess_type', ['cmid' => $newcm->id]);
+        $this->assertNotEmpty($record);
+        $this->assertEquals($expectedtype, (int)$record->type);
+        $this->assertEquals($expectedlocked, (int)$record->locked);
+    }
+
+    /**
+     * Test duplicating an activity with no assess_type record creates no record for the duplicate.
+     *
+     * @covers \restore_local_assess_type_plugin::after_restore_module
+     */
+    public function test_duplicate_module_with_no_assess_type_creates_no_record(): void {
+        global $DB;
+        [$course, $assign] = $this->create_course_with_assign();
+
+        $newcm = duplicate_module($course, get_fast_modinfo($course)->get_cm($assign->cmid));
+
+        $this->assertFalse($DB->record_exists('local_assess_type', ['cmid' => $newcm->id]));
+    }
+
+    /**
+     * Create a course with an assignment module.
+     *
+     * @return array Array containing the course object and the assign module object.
+     */
+    private function create_course_with_assign(): array {
+        $course = $this->getDataGenerator()->create_course();
+        $assign = $this->getDataGenerator()->create_module('assign', ['course' => $course->id, 'name' => 'Test Assignment']);
+
+        return [$course, $assign];
     }
 }


### PR DESCRIPTION
CTP-5218
- Added event observers to delete orphaned local_assess_type records when a
  course module or grade item is deleted
- Added scheduled task to clean up any pre-existing orphaned records

CTP-6322
- Fix course module duplication assess type is not carried over issue